### PR TITLE
Update stroke colours to meet approx 7:1 contrast

### DIFF
--- a/colors/ColorPopupProvider.js
+++ b/colors/ColorPopupProvider.js
@@ -24,23 +24,23 @@ ColorPopupProvider.prototype.getEntries = function(element) {
   }, {
     label: 'Blue',
     fill: '#BBDEFB',
-    stroke: '#1E88E5'
+    stroke: '#0D4372'
   }, {
     label: 'Orange',
     fill: '#FFE0B2',
-    stroke: '#FB8C00'
+    stroke: '#6B3C00'
   }, {
     label: 'Green',
     fill: '#C8E6C9',
-    stroke: '#43A047'
+    stroke: '#205022'
   }, {
     label: 'Red',
     fill: '#FFCDD2',
-    stroke: '#E53935'
+    stroke: '#831311'
   }, {
     label: 'Purple',
     fill: '#E1BEE7',
-    stroke: '#8E24AA'
+    stroke: '#5B176D'
   }];
 
   var entries = colors.map(function(color) {


### PR DESCRIPTION
This changes the stroke colours in order to increase contrast against the related fill colours.

Currently, none of the combinations meet the contrast requirements for regular text as required by WGAC 2.1, some choices (particularly orange and green) are difficult to distinguish and will pose potential issues for anyone with visual impairments. 

This represents a failure to meet the following accessibility guidelines:
1. AA https://www.w3.org/TR/WCAG21/#contrast-minimum
2. AAA https://www.w3.org/TR/WCAG21/#contrast-enhanced

All stroke colours have been darkened to at least a 7:1 contrast ratio against the fill, allowing the elements to meet AAA requirements for 'regular' text and meet both success criteria 1.4.4 (minimum) and 1.4.6 (enhanced) while still providing a pleasing colour choice.

*Before*
![Screenshot 2022-10-19 at 13 58 15](https://user-images.githubusercontent.com/18653/196698862-1506bff9-170e-4690-a9c5-e73860face2c.png)

*After*
![Screenshot 2022-10-19 at 13 45 17](https://user-images.githubusercontent.com/18653/196698902-fce1426d-ca2e-4fd2-92e3-f0d72201f2a5.png)

*Alternative solutions*
It may be preferable to keep the outline border as-is and only modify the text and icon colours to either the darkened variants, or simply back to black.
