### PR TITLE
Change how icons are loaded and fit in dark mode.Change stroke-width to 2 to make it clearer

### DIFF
--- a/colors/ColorContextPadProvider.js
+++ b/colors/ColorContextPadProvider.js
@@ -1,7 +1,5 @@
 const colorImageSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22"><path d="m12.5 5.5.3-.4 3.6-3.6c.5-.5 1.3-.5 1.7 0l1 1c.5.4.5 1.2 0 1.7l-3.6 3.6-.4.2v.2c0 1.4.6 2 1 2.7v.6l-1.7 1.6c-.2.2-.4.2-.6 0L7.3 6.6a.4.4 0 0 1 0-.6l.3-.3.5-.5.8-.8c.2-.2.4-.1.6 0 .9.5 1.5 1.1 3 1.1zm-9.9 6 4.2-4.2 6.3 6.3-4.2 4.2c-.3.3-.9.3-1.2 0l-.8-.8-.9-.8-2.3-2.9" /></svg>';
 
-const colorImageUrl = 'data:image/svg+xml;utf8,' + encodeURIComponent(colorImageSvg);
-
 
 export default function ColorContextPadProvider(contextPad, popupMenu, canvas, translate) {
 
@@ -44,7 +42,7 @@ ColorContextPadProvider.prototype._createPopupAction = function(elements) {
       group: 'edit',
       className: 'bpmn-icon-color',
       title: translate('Set Color'),
-      imageUrl: colorImageUrl,
+      html: `<div class="entry"> ${colorImageSvg}</div>`,
       action: {
         click: (event, element) => {
 
@@ -53,15 +51,15 @@ ColorContextPadProvider.prototype._createPopupAction = function(elements) {
             ...getStartPosition(canvas, contextPad, elements),
             cursor: {
               x: event.x,
-              y: event.y
-            }
+              y: event.y,
+            },
           };
 
           // open new color-picker popup
           popupMenu.open(elements, 'color-picker', position);
-        }
-      }
-    }
+        },
+      },
+    },
   };
 
 };

--- a/colors/ColorPopupProvider.js
+++ b/colors/ColorPopupProvider.js
@@ -1,52 +1,59 @@
-import {
-  domify
-} from 'min-dom';
+import { domify } from 'min-dom';
 
-const COLORS = [ {
-  label: 'Default',
-  fill: undefined,
-  stroke: undefined
-}, {
-  label: 'Blue',
-  fill: '#BBDEFB',
-  stroke: '#0D4372'
-}, {
-  label: 'Orange',
-  fill: '#FFE0B2',
-  stroke: '#6B3C00'
-}, {
-  label: 'Green',
-  fill: '#C8E6C9',
-  stroke: '#205022'
-}, {
-  label: 'Red',
-  fill: '#FFCDD2',
-  stroke: '#831311'
-}, {
-  label: 'Purple',
-  fill: '#E1BEE7',
-  stroke: '#5B176D'
-} ];
+const COLORS = [
+  {
+    label: 'Default',
+    fill: undefined,
+    stroke: undefined,
+  },
+  {
+    label: 'Blue',
+    fill: '#BBDEFB',
+    stroke: '#0D4372',
+  },
+  {
+    label: 'Orange',
+    fill: '#FFE0B2',
+    stroke: '#6B3C00',
+  },
+  {
+    label: 'Green',
+    fill: '#C8E6C9',
+    stroke: '#205022',
+  },
+  {
+    label: 'Red',
+    fill: '#FFCDD2',
+    stroke: '#831311',
+  },
+  {
+    label: 'Purple',
+    fill: '#E1BEE7',
+    stroke: '#5B176D',
+  },
+];
 
-
-export default function ColorPopupProvider(config, popupMenu, modeling, translate) {
+export default function ColorPopupProvider(
+    config,
+    popupMenu,
+    modeling,
+    translate
+) {
   this._popupMenu = popupMenu;
   this._modeling = modeling;
   this._translate = translate;
 
-  this._colors = config && config.colors || COLORS;
-
+  this._colors = (config && config.colors) || COLORS;
+  this._theme = (config && config.theme) || 'light';
   this._popupMenu.registerProvider('color-picker', this);
 }
-
 
 ColorPopupProvider.$inject = [
   'config.colorPicker',
   'popupMenu',
   'modeling',
-  'translate'
+  'translate',
 ];
-
 
 ColorPopupProvider.prototype.getEntries = function(elements) {
   var self = this;
@@ -56,23 +63,29 @@ ColorPopupProvider.prototype.getEntries = function(elements) {
       <rect rx="2" x="1" y="1" width="22" height="22" fill="var(--fill-color)" stroke="var(--stroke-color)"></rect>
     </svg>
   `);
-
+  const theme = (this._theme && this._theme) || 'light';
+  const defaultFill = theme == 'light' ? 'white' : 'black';
+  const defaultStroke =
+    theme == 'light' ? 'rgb(34, 36, 42)' : 'rgb(221, 219, 213)';
   var entries = this._colors.map(function(color) {
-
-    colorIcon.style.setProperty('--fill-color', color.fill || 'white');
-    colorIcon.style.setProperty('--stroke-color', color.stroke || 'rgb(34, 36, 42)');
+    colorIcon.style.setProperty('--fill-color', color.fill || defaultFill);
+    colorIcon.style.setProperty(
+      '--stroke-color',
+      color.stroke || defaultStroke
+    );
 
     return {
       title: self._translate(color.label),
       id: color.label.toLowerCase() + '-color',
-      imageUrl: `data:image/svg+xml;utf8,${ encodeURIComponent(colorIcon.outerHTML) }`,
-      action: createAction(self._modeling, elements, color)
+      imageUrl: `data:image/svg+xml;utf8,${encodeURIComponent(
+        colorIcon.outerHTML
+      )}`,
+      action: createAction(self._modeling, elements, color),
     };
   });
 
   return entries;
 };
-
 
 function createAction(modeling, element, color) {
   return function() {

--- a/colors/ColorPopupProvider.js
+++ b/colors/ColorPopupProvider.js
@@ -60,7 +60,7 @@ ColorPopupProvider.prototype.getEntries = function(elements) {
 
   var colorIcon = domify(`
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" height="100%">
-      <rect rx="2" x="1" y="1" width="22" height="22" fill="var(--fill-color)" stroke="var(--stroke-color)"></rect>
+      <rect rx="2" x="1" y="1" width="22" height="22" fill="var(--fill-color)" stroke="var(--stroke-color)" style="stroke-width:2"></rect>
     </svg>
   `);
   const theme = (this._theme && this._theme) || 'light';


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
1. Change the icon loading mode to html so that you can change the color
using the css
```
.djs-context-pad > .group .bpmn-icon-color {
    fill: #1e80ff !important;
}
```
<img width="436" alt="image" src="https://user-images.githubusercontent.com/62740686/235298230-6b837302-feae-4c63-b91b-11c1941019bc.png">

2. Change the color's default fill color and stroke color by adding a theme configuration to fit the dark mode
```
colorPicker: {
    colors: CUSTOM_COLOR_PICKER_COLORS,
    theme:'dark' // light(default) or dark
 }
```
<img width="864" alt="image" src="https://user-images.githubusercontent.com/62740686/235298153-c9366ec2-1774-461f-96de-53c5de8da298.png">

3. Change colorIcon stroke-width to 2 to make it clearer
