### PR TITLE
feat: change the icon loading mode

### DIFF
--- a/colors/ColorContextPadProvider.js
+++ b/colors/ColorContextPadProvider.js
@@ -1,7 +1,5 @@
 const colorImageSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22"><path d="m12.5 5.5.3-.4 3.6-3.6c.5-.5 1.3-.5 1.7 0l1 1c.5.4.5 1.2 0 1.7l-3.6 3.6-.4.2v.2c0 1.4.6 2 1 2.7v.6l-1.7 1.6c-.2.2-.4.2-.6 0L7.3 6.6a.4.4 0 0 1 0-.6l.3-.3.5-.5.8-.8c.2-.2.4-.1.6 0 .9.5 1.5 1.1 3 1.1zm-9.9 6 4.2-4.2 6.3 6.3-4.2 4.2c-.3.3-.9.3-1.2 0l-.8-.8-.9-.8-2.3-2.9" /></svg>';
 
-const colorImageUrl = 'data:image/svg+xml;utf8,' + encodeURIComponent(colorImageSvg);
-
 
 export default function ColorContextPadProvider(contextPad, popupMenu, canvas, translate) {
 
@@ -44,7 +42,7 @@ ColorContextPadProvider.prototype._createPopupAction = function(elements) {
       group: 'edit',
       className: 'bpmn-icon-color',
       title: translate('Set Color'),
-      imageUrl: colorImageUrl,
+      html: `<div class="entry">${colorImageSvg}</div>`,
       action: {
         click: (event, element) => {
 

--- a/colors/ColorPopupProvider.js
+++ b/colors/ColorPopupProvider.js
@@ -35,6 +35,8 @@ export default function ColorPopupProvider(config, popupMenu, modeling, translat
   this._translate = translate;
 
   this._colors = config && config.colors || COLORS;
+  this._defaultFill = config && config.defaultFill || 'white';
+  this._defaultStroke = config && config.defaultStroke || 'rgb(34, 36, 42)';
 
   this._popupMenu.registerProvider('color-picker', this);
 }
@@ -59,8 +61,8 @@ ColorPopupProvider.prototype.getEntries = function(elements) {
 
   var entries = this._colors.map(function(color) {
 
-    colorIcon.style.setProperty('--fill-color', color.fill || 'white');
-    colorIcon.style.setProperty('--stroke-color', color.stroke || 'rgb(34, 36, 42)');
+    colorIcon.style.setProperty('--fill-color', color.fill || self._defaultFill);
+    colorIcon.style.setProperty('--stroke-color', color.stroke || self._defaultStroke);
 
     return {
       title: self._translate(color.label),


### PR DESCRIPTION
 Change the icon loading mode to html so that you can change the color
using the css
```
.djs-context-pad > .group .bpmn-icon-color {
    fill: #1e80ff !important;
}
```
<img width="436" alt="image" src="https://user-images.githubusercontent.com/62740686/235298230-6b837302-feae-4c63-b91b-11c1941019bc.png">
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
