### PR TITLE
feat: added configuration default fill color and default stroke color

### DIFF
--- a/colors/ColorPopupProvider.js
+++ b/colors/ColorPopupProvider.js
@@ -29,14 +29,14 @@ const COLORS = [ {
 } ];
 
 
-export default function ColorPopupProvider(config, popupMenu, modeling, translate) {
+export default function ColorPopupProvider(config, bpmnRendererConfig, popupMenu, modeling, translate) {
   this._popupMenu = popupMenu;
   this._modeling = modeling;
   this._translate = translate;
 
   this._colors = config && config.colors || COLORS;
-  this._defaultFillColor = config && config.defaultFillColor || 'white';
-  this._defaultStrokeColor = config && config.defaultStrokeColor || 'rgb(34, 36, 42)';
+  this._defaultFillColor = bpmnRendererConfig && bpmnRendererConfig.defaultFillColor || 'white';
+  this._defaultStrokeColor = bpmnRendererConfig && bpmnRendererConfig.defaultStrokeColor || 'rgb(34, 36, 42)';
 
   this._popupMenu.registerProvider('color-picker', this);
 }
@@ -44,6 +44,7 @@ export default function ColorPopupProvider(config, popupMenu, modeling, translat
 
 ColorPopupProvider.$inject = [
   'config.colorPicker',
+  'config.bpmnRenderer',
   'popupMenu',
   'modeling',
   'translate'

--- a/colors/ColorPopupProvider.js
+++ b/colors/ColorPopupProvider.js
@@ -35,6 +35,8 @@ export default function ColorPopupProvider(config, popupMenu, modeling, translat
   this._translate = translate;
 
   this._colors = config && config.colors || COLORS;
+  this._defaultFillColor = config && config.defaultFillColor || 'white';
+  this._defaultStrokeColor = config && config.defaultStrokeColor || 'rgb(34, 36, 42)';
 
   this._popupMenu.registerProvider('color-picker', this);
 }
@@ -53,14 +55,14 @@ ColorPopupProvider.prototype.getEntries = function(elements) {
 
   var colorIcon = domify(`
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" height="100%">
-      <rect rx="2" x="1" y="1" width="22" height="22" fill="var(--fill-color)" stroke="var(--stroke-color)"></rect>
+      <rect rx="2" x="1" y="1" width="22" height="22" fill="var(--fill-color)" stroke="var(--stroke-color)" style="stroke-width:2"></rect>
     </svg>
   `);
 
   var entries = this._colors.map(function(color) {
 
-    colorIcon.style.setProperty('--fill-color', color.fill || 'white');
-    colorIcon.style.setProperty('--stroke-color', color.stroke || 'rgb(34, 36, 42)');
+    colorIcon.style.setProperty('--fill-color', color.fill || self._defaultFillColor);
+    colorIcon.style.setProperty('--stroke-color', color.stroke || self._defaultStrokeColor);
 
     return {
       title: self._translate(color.label),


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
1. Added configuration default fill color and default stroke color.This makes some special environment display better(such as dark mode).This configuration is consistent with bpmn js
2. Adjust the color svg icon stroke-width to equal 2 so that the border color is clearer
<img width="422" alt="iShot_2023-05-25_15 55 38" src="https://github.com/bpmn-io/bpmn-js-color-picker/assets/62740686/983c185f-5e5e-4aeb-8797-7abb1b8482ba">
<img width="353" alt="iShot_2023-05-25_15 55 15" src="https://github.com/bpmn-io/bpmn-js-color-picker/assets/62740686/0e8d7f57-c8ed-473a-b59a-159961bae3bf">

