### PR TITLE
fix: set `fill=currentColor` on icon

### DIFF
--- a/colors/ColorContextPadProvider.js
+++ b/colors/ColorContextPadProvider.js
@@ -1,6 +1,6 @@
-const colorImageSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22"><path d="m12.5 5.5.3-.4 3.6-3.6c.5-.5 1.3-.5 1.7 0l1 1c.5.4.5 1.2 0 1.7l-3.6 3.6-.4.2v.2c0 1.4.6 2 1 2.7v.6l-1.7 1.6c-.2.2-.4.2-.6 0L7.3 6.6a.4.4 0 0 1 0-.6l.3-.3.5-.5.8-.8c.2-.2.4-.1.6 0 .9.5 1.5 1.1 3 1.1zm-9.9 6 4.2-4.2 6.3 6.3-4.2 4.2c-.3.3-.9.3-1.2 0l-.8-.8-.9-.8-2.3-2.9" /></svg>';
-
-
+const colorImageSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" fill="currentColor">
+  <path d="m12.5 5.5.3-.4 3.6-3.6c.5-.5 1.3-.5 1.7 0l1 1c.5.4.5 1.2 0 1.7l-3.6 3.6-.4.2v.2c0 1.4.6 2 1 2.7v.6l-1.7 1.6c-.2.2-.4.2-.6 0L7.3 6.6a.4.4 0 0 1 0-.6l.3-.3.5-.5.8-.8c.2-.2.4-.1.6 0 .9.5 1.5 1.1 3 1.1zm-9.9 6 4.2-4.2 6.3 6.3-4.2 4.2c-.3.3-.9.3-1.2 0l-.8-.8-.9-.8-2.3-2.9" />
+</svg>`;
 
 
 export default function ColorContextPadProvider(contextPad, popupMenu, canvas, translate) {


### PR DESCRIPTION
This ensures icon can be styled on hover (assuming `color` hover styles):

![capture 1h8v94_optimized](https://github.com/bpmn-io/bpmn-js-color-picker/assets/58601/31784e14-5dd9-4c6e-9a39-5d880e43d0d7)


----

Related to https://github.com/bpmn-io/bpmn-js-create-append-anything/pull/10